### PR TITLE
Set "use client" only for DropdownMenu component

### DIFF
--- a/components/home/AboutSection.tsx
+++ b/components/home/AboutSection.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import ReactMarkdown from 'react-markdown'
 import PhotoCarousel from "@/components/media/PhotoCarousel";
 import MapWrapper from "@/components/map/MapWrapper";

--- a/components/home/ContactSection.tsx
+++ b/components/home/ContactSection.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Contact } from "@/types/strapi.type";
 import ContactLink from "@/components/ui/ContactLink";
 

--- a/components/home/HeaderIntro.tsx
+++ b/components/home/HeaderIntro.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import Image from 'next/image'
 import Link from 'next/link'
 import {useTranslations} from "next-intl";

--- a/components/home/SkillsGrid.tsx
+++ b/components/home/SkillsGrid.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Skill } from "@/types/strapi.type";
 import SkillCard from "@/components/ui/SkillCard";
 import Section from "@/components/ui/Section";

--- a/components/ui/DropdownMenu.tsx
+++ b/components/ui/DropdownMenu.tsx
@@ -1,3 +1,4 @@
+"use client"
 import React, {useState, useRef, RefObject} from 'react';
 import Link from 'next/link';
 import { useClickOutside } from '@/hooks/useClickOutside';


### PR DESCRIPTION
Moved the "use client" directive to DropdownMenu.tsx to optimize the usage of client-side rendering. Removed it from other components where it was not necessary, reducing client-side overhead.